### PR TITLE
ci: add build-and-deploy workflow for VUE

### DIFF
--- a/.github/workflows/vue-build-deploy.yml
+++ b/.github/workflows/vue-build-deploy.yml
@@ -1,0 +1,31 @@
+name: Build & Deploy Vue SPA to Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build      # package.json build must output to ./docs or ./dist
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: main      
+          publish_dir: ./docs       # or ./dist dep. on build folder


### PR DESCRIPTION
I’ve added a GitHub Actions workflow under .github/workflows/vue-build-deploy.yml that will automatically build our Vue app and deploy it to Pages on every push to branch 'main'. It uses the built-in GITHUB_TOKEN, so no extra secrets are needed. Once PR is merged, pushing Vue code directly to main results in Page updating itself.