### PR TITLE
update configs for ci/cd

### DIFF
--- a/.github/workflows/vue-build-deploy.yml
+++ b/.github/workflows/vue-build-deploy.yml
@@ -37,4 +37,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # If you serve from the main branch’s docs/ folder:
           publish_branch: gh-pages
-          publish_dir: docs
+          publish_dir: docs 

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,9 +9,10 @@ globalThis.crypto = webcrypto
 
 export default defineConfig({
   // Use root "/" in development, and your GitHub Pages sub-path in production
-  base: process.env.NODE_ENV === 'production'
+  /*base: process.env.NODE_ENV === 'production'
     ? '/danieldanlab.github.io/'
-    : '/',
+    : '/',*/
+    base: './',
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
root dir is now './' which should make us more flexible because there is no restraint regarding specific link of the respective supporting files.